### PR TITLE
Right brace

### DIFF
--- a/libsass_dir/src/emitter.cpp
+++ b/libsass_dir/src/emitter.cpp
@@ -286,7 +286,9 @@ namespace Sass {
     } else {
       append_optional_space();
     }
-    append_string("\n}\n");
+    append_string("\n");
+    append_indentation();
+    append_string("}");
     if (node) add_close_mapping(node);
     append_optional_linefeed();
     if (indentation != 0) return;

--- a/libsass_dir/src/emitter.cpp
+++ b/libsass_dir/src/emitter.cpp
@@ -286,7 +286,7 @@ namespace Sass {
     } else {
       append_optional_space();
     }
-    append_string("}");
+    append_string("\n}");
     if (node) add_close_mapping(node);
     append_optional_linefeed();
     if (indentation != 0) return;

--- a/libsass_dir/src/emitter.cpp
+++ b/libsass_dir/src/emitter.cpp
@@ -286,7 +286,7 @@ namespace Sass {
     } else {
       append_optional_space();
     }
-    append_string("\n}");
+    append_string("\n}\n");
     if (node) add_close_mapping(node);
     append_optional_linefeed();
     if (indentation != 0) return;

--- a/libsass_dir/src/emitter.cpp
+++ b/libsass_dir/src/emitter.cpp
@@ -286,8 +286,12 @@ namespace Sass {
     } else {
       append_optional_space();
     }
+    // 다른 ruleset과 구분하기 위해 linefeed
     append_string("\n");
+    // @media 등 ruleset의 계층구조가 남아있을 시 내부 Ruleset에서 indentation 추가 적용
+    // Global Scope인 경우에는 indentation값이 0이므로 없는 코드와 동일함.
     append_indentation();
+    // right brace 추가
     append_string("}");
     if (node) add_close_mapping(node);
     append_optional_linefeed();

--- a/libsass_dir/src/emitter.cpp
+++ b/libsass_dir/src/emitter.cpp
@@ -288,7 +288,7 @@ namespace Sass {
     }
     // 다른 ruleset과 구분하기 위해 linefeed
     append_string("\n");
-    // @media 등 ruleset의 계층구조가 남아있을 시 내부 Ruleset에서 indentation 추가 적용
+    // @media 등 ruleset의 계층구조가 남아있을 시 내부 Ruleset에서 오른쪽 괄호에 indentation 추가 적용
     // Global Scope인 경우에는 indentation값이 0이므로 없는 코드와 동일함.
     append_indentation();
     // right brace 추가

--- a/libsass_dir/src/inspect.cpp
+++ b/libsass_dir/src/inspect.cpp
@@ -29,11 +29,11 @@ namespace Sass {
       add_open_mapping(block);
       append_scope_opener();
     }
-    if (output_style() == NESTED) indentation += block->tabs();
+    //if (output_style() == NESTED) indentation += block->tabs();
     for (size_t i = 0, L = block->length(); i < L; ++i) {
       (*block)[i]->perform(this);
     }
-    if (output_style() == NESTED) indentation -= block->tabs();
+    //if (output_style() == NESTED) indentation -= block->tabs();
     if (!block->is_root()) {
       append_scope_closer();
       add_close_mapping(block);
@@ -78,8 +78,7 @@ namespace Sass {
 
   void Inspect::operator()(CssMediaRule* rule)
   {
-    if (output_style() == NESTED)
-      indentation += rule->tabs();
+    //if (output_style() == NESTED) indentation += rule->tabs();
     append_indentation();
     append_token("@media", rule);
     append_mandatory_space();
@@ -97,8 +96,7 @@ namespace Sass {
       rule->block()->perform(this);
     }
     in_media_block = false;
-    if (output_style() == NESTED)
-      indentation -= rule->tabs();
+    //if (output_style() == NESTED) indentation -= rule->tabs();
   }
 
   void Inspect::operator()(CssMediaQuery* query)
@@ -171,8 +169,7 @@ namespace Sass {
     in_declaration = true;
     LOCAL_FLAG(in_custom_property, dec->is_custom_property());
 
-    if (output_style() == NESTED)
-      indentation += dec->tabs();
+    //if (output_style() == NESTED) indentation += dec->tabs();
     append_indentation();
     if (dec->property())
       dec->property()->perform(this);
@@ -190,8 +187,7 @@ namespace Sass {
       append_string("!important");
     }
     append_delimiter();
-    if (output_style() == NESTED)
-      indentation -= dec->tabs();
+    //if (output_style() == NESTED) indentation -= dec->tabs();
     in_declaration = was_decl;
   }
 

--- a/libsass_dir/src/output.cpp
+++ b/libsass_dir/src/output.cpp
@@ -131,9 +131,7 @@ namespace Sass {
       return;
     }
 
-    if (output_style() == NESTED) {
-      indentation += r->tabs();
-    }
+    //if (output_style() == NESTED) indentation += r->tabs();
     if (opt.source_comments) {
       sass::ostream ss;
       append_indentation();
@@ -172,7 +170,7 @@ namespace Sass {
         stm->perform(this);
       }
     }
-    if (output_style() == NESTED) indentation -= r->tabs();
+    //if (output_style() == NESTED) indentation -= r->tabs();
     append_scope_closer(b);
 
   }

--- a/libsass_dir/src/parser.cpp
+++ b/libsass_dir/src/parser.cpp
@@ -129,7 +129,6 @@ namespace Sass {
     }
     // create new block and push to the selector stack
     Block_Obj block = SASS_MEMORY_NEW(Block, pstate, 0, is_root);
-    std::cout << "This is " << block->to_string() << std::endl;
 
     // left brace 이후로 새로운 블록이기 때문에 block stack에 block을 추가함
     block_stack.push_back(block);
@@ -169,7 +168,6 @@ namespace Sass {
   // lexing하면서 parsing (lexing 다하고 parsing하는게 아님. lexing을 하면서 parsing을 같이 진행함)
   bool Parser::parse_block_nodes(bool is_root)
   {
-    //std::cout << "is_root: " << is_root << ", Hello World!" << std::endl;
     // loop until end of string
     while (position < end) {
       // we should be able to refactor this
@@ -987,7 +985,6 @@ namespace Sass {
     }
     bool is_indented = true; // sass 문법이라서 우리는 관여하지 않을 것
     const sass::string property(lexed);
-    //std::cout << "Hello, " << property << std::endl;
     if (!lex_css< one_plus< exactly<':'> > >()) error("property \"" + escape_string(property)  + "\" must be followed by a ':'");
     // custom variable은 colon 뒤에 comment, semi colon 붙여도 되는데 non-custom variable은 불가능함
     // ex) background-color: /* */; -> error,        --sadf: /* asdf */; -> non error

--- a/libsass_dir/src/parser.cpp
+++ b/libsass_dir/src/parser.cpp
@@ -129,6 +129,7 @@ namespace Sass {
     }
     // create new block and push to the selector stack
     Block_Obj block = SASS_MEMORY_NEW(Block, pstate, 0, is_root);
+    std::cout << "This is " << block->to_string() << std::endl;
 
     // left brace 이후로 새로운 블록이기 때문에 block stack에 block을 추가함
     block_stack.push_back(block);

--- a/libsass_dir/src/sass_context.cpp
+++ b/libsass_dir/src/sass_context.cpp
@@ -346,7 +346,7 @@ extern "C" {
   inline void init_options (struct Sass_Options* options)
   {
     options->precision = 10;
-    options->indent = "    ";
+    options->indent = "  ";
     options->linefeed = LFEED; // LFEED = '\n'
   }
 

--- a/libsass_dir/src/sass_context.cpp
+++ b/libsass_dir/src/sass_context.cpp
@@ -346,7 +346,7 @@ extern "C" {
   inline void init_options (struct Sass_Options* options)
   {
     options->precision = 10;
-    options->indent = "  ";
+    options->indent = "    ";
     options->linefeed = LFEED; // LFEED = '\n'
   }
 

--- a/test
+++ b/test
@@ -4,4 +4,3 @@ cd ../sassc_dir
 SASS_LIBSASS_PATH=../libsass_dir make
 cd ..
 ./sassc_dir/bin/sassc input.scss output.css
-rm ./sassc_dir/bin/sassc


### PR DESCRIPTION
1. 오른쪽 괄호가 linefeed 없이 닫히는 문제점을 해결하였습니다.

2. 내부 scope ruleset이 의미 없이 indentation을 가지는 문제점을 해결하였습니다.

3. 2번 구현 때문에 생기는, @media 등과 같은 annotation에서 보존되어야 하는 right brace의 문제점을 해결하였습니다.